### PR TITLE
bypass checks on ipv6 addresses for now

### DIFF
--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -437,7 +437,7 @@ defmodule Xandra.Cluster do
       raise ArgumentError, "the :sync_connect option is only supported on Erlang/OTP 24+"
     end
 
-    defp unalias(alias), do: raise(ArgumentError, "should never reach this")
+    defp unalias(_alias), do: raise(ArgumentError, "should never reach this")
   end
 
   @doc """

--- a/lib/xandra/cluster.ex
+++ b/lib/xandra/cluster.ex
@@ -773,7 +773,9 @@ defmodule Xandra.Cluster do
   defp start_pool(state, %Host{} = host) do
     conn_options =
       Keyword.merge(state.pool_options,
-        nodes: [Host.format_address(host)],
+        # NimbleOptions.validate! validate_node fails on ipv6 transformations
+        # nodes: Host.format_address(host)
+        nodes: [host],
         registry: state.registry,
         connection_listeners: [state.control_connection]
       )

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -727,7 +727,8 @@ defmodule Xandra.Cluster.ControlConnection do
       {host, port} ->
         %Host{address: host, port: port}
 
-      %Host{address: host, port: port} = _contact_point -> %Host{address: host, port: port}
+      %Host{address: host, port: port} = _contact_point ->
+        %Host{address: host, port: port}
 
       contact_point ->
         {:ok, {host, port}} = Xandra.OptionsValidators.validate_node(contact_point)

--- a/lib/xandra/cluster/control_connection.ex
+++ b/lib/xandra/cluster/control_connection.ex
@@ -727,6 +727,8 @@ defmodule Xandra.Cluster.ControlConnection do
       {host, port} ->
         %Host{address: host, port: port}
 
+      %Host{address: host, port: port} = _contact_point -> %Host{address: host, port: port}
+
       contact_point ->
         {:ok, {host, port}} = Xandra.OptionsValidators.validate_node(contact_point)
         %Host{address: host, port: port}

--- a/lib/xandra/options_validators.ex
+++ b/lib/xandra/options_validators.ex
@@ -40,6 +40,10 @@ defmodule Xandra.OptionsValidators do
     end
   end
 
+  def validate_node(%Xandra.Cluster.Host{address: address, port: port}) do
+    {:ok, {address, port}}
+  end
+
   def validate_node(other) do
     {:error, "expected node to be a string or a {ip, port} tuple, got: #{inspect(other)}"}
   end

--- a/test/integration/cluster_test.exs
+++ b/test/integration/cluster_test.exs
@@ -420,8 +420,7 @@ defmodule Xandra.ClusterTest do
   end
 
   defp assert_pool_started(test_ref, %Host{} = host) do
-    node = Host.format_address(host)
-    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^node]}}
+    assert_receive {^test_ref, PoolMock, :init_called, %{nodes: [^host]}}
   end
 
   defp refute_other_pools_started(test_ref) do


### PR DESCRIPTION
We are using this lib and the host structs are returning ipv6 addresses for our clusters. The `validate_node` function is failing on ipv6 addresses

"The pool supervisor will run the validations again on the ipv6 values returned in https://github.com/lexhide/xandra/blob/v0.16.0/lib/xandra/cluster.ex#L793 and in the logs we see that our hosts are returned with both ipv4 and ipv6 addresses. The ipv6 addresses are being used and fail to validate." - @britto 

```
invalid value for list element at position 0: invalid node: \"xxxx:xxxx:xxxx:xxxx:0:xxx:xxxx:xxxx:xxxxx\"", value: ["xxxx:xxxx:xxxx:xxxx:0:xxx:xxxx:xxxx:xxxxx"]}, [{NimbleOptions, :validate!, 2, [file: 'lib/nimble_options.ex', line: 343]}
```
```
     (xandra 0.16.0) lib/xandra/cluster.ex:750: Xandra.Cluster.start_pool/2
     (xandra 0.16.0) lib/xandra/cluster.ex:798: anonymous fn/4 in Xandra.Cluster.maybe_start_pools/1
     (elixir 1.12.3) lib/enum.ex:4286: Enumerable.List.reduce/3
     (elixir 1.12.3) lib/enum.ex:2431: Enum.reduce_while/3
     (xandra 0.16.0) lib/xandra/cluster.ex:726: Xandra.Cluster.handle_info/2
     (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
     (stdlib 3.17.2) gen_server.erl:771: :gen_server.handle_msg/6
```